### PR TITLE
Optimize health check in rpc proxy

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -34,6 +34,8 @@ This file recognizes the individuals who have contributed to the development of 
 
 _This section will be updated as the project receives contributions from the community._
 
+- ret2happy (@ret2happy)
+
 ### How to Get Listed
 
 Contributors are automatically added to this file when they:


### PR DESCRIPTION
Sometimes when we config bunch of network urls, the initial health check can take too much time. Here we optimize health check in rpc proxy by making the requests in parallel.