### PR TITLE
fix: bind on all interfaces

### DIFF
--- a/crates/rpc-proxy/src/bin/main.rs
+++ b/crates/rpc-proxy/src/bin/main.rs
@@ -24,9 +24,9 @@ use clap::{Parser, Subcommand};
 use edb_common::init_file_only_logging;
 use edb_common::init_logging;
 use eyre::Result;
-use std::str::FromStr;
 use std::net::IpAddr;
 use std::net::SocketAddr;
+use std::str::FromStr;
 use tracing::{info, warn};
 
 use edb_rpc_proxy::proxy;


### PR DESCRIPTION
Right now we are binding on localhost, this makes it reject remote calls. Binding to 0.0.0.0 allows them.

Alternatively, as a feature request, this could be passed in as args by the user?