### PR TITLE
Update Claude review workflow to trigger only when TroublorBot is requested

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [review_requested]
     # Optional: Only run on specific file changes
     # paths:
     #   - "src/**/*.ts"
@@ -12,6 +12,7 @@ on:
 
 jobs:
   claude-review:
+    if: ${{ github.event.requested_reviewer.login == 'TroublorBot' }}
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -54,4 +55,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://docs.claude.com/en/docs/claude-code/cli-reference for available options
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
-


### PR DESCRIPTION
## Summary
- Changed workflow trigger from `[opened, synchronize]` to `[review_requested]`
- Added condition to only run when TroublorBot is requested as a reviewer
- This ensures Claude Code review only runs when explicitly requested

## Changes
- Workflow now triggers on `review_requested` event instead of every PR open/update
- Added `if` condition to check for TroublorBot as the requested reviewer