### PR TITLE
chore: bump workspace to 0.0.3 + security fixes + 0.0.3 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,19 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2026-05-10
+
 ### Added
 - Support for calldata variables ([#33](https://github.com/edb-rs/edb/pull/33))
-- Add new `r` and `R` commands in code panel (`run`/`runback` in terminal panels) to run forward/backward until the next breakpoint
-- Add `edb server` which collectively spawns edb debug server. ([#46](https://github.com/edb-rs/edb/pull/46))
-- Add `release.yml` for automatic release publishing to GitHub Releases
+- New `r` and `R` commands in code panel (`run`/`runback` in terminal panels) to run forward/backward until the next breakpoint
+- `edb server` which collectively spawns edb debug server. ([#46](https://github.com/edb-rs/edb/pull/46))
+- `release.yml` for automatic release publishing to GitHub Releases
+- **Browser-based web UI** as the default front-end: file tabs (Dockview), CodeMirror Solidity editor, command palette, debug toolbar with VSCode-style F-key bindings, Variables/Watch sidebar, Display panel (Stack / Memory / Storage / Transient / Calldata / Output), Terminal panel, and reopen menu. Source views auto-scroll to the active line; opcode views highlight the current PC and recover from missed scrolls via a global "Where am I?" toolbar button.
+- **Marketing website** (`website/`) with a fixed-shell tour, IDE mock, mobile-sheet popups, and a rotate-phone overlay; `edb.zzhang.xyz` runs the same bundle.
+- README: online tutor badge, sponsor split (GitHub Sponsors for individuals, mailto for companies, with a subtle DAPLab @ Columbia attribution).
 
 ### Fixed
-- Struct fields are no longer be incorrectly treated as variables ([#33](https://github.com/edb-rs/edb/pull/33))
+- Struct fields are no longer incorrectly treated as variables ([#33](https://github.com/edb-rs/edb/pull/33))
 - Gas limit relaxation is now correctly applied at callsites ([#39](https://github.com/edb-rs/edb/issues/39))
+- Web Memory view rendered nothing for opcode snapshots with empty memory; now shows an explicit `(empty)` placeholder.
+- Web opcode view's auto-scroll lost its target on backward navigation due to a single-ref-swap pattern; replaced with a `data-edb-current` attribute lookup that's order-independent.
+- Web tab focus didn't follow the active snapshot across contracts; `MainArea` now opens (or focuses) the file/disasm tab matching the snapshot on every change.
 
 ### Changed
-
-- Update `install.sh` to download the latest release from GitHub Releases first, and fallback to building from source if no releases are found.
+- `--ui` defaults to `web` (was `tui`); `--ui=tui` is the explicit fallback. Release pipeline already installs Bun, so prebuilt binaries ship with the embedded SPA baked in.
+- Reverse Step (`⌥F10`) is now a true history-pop ("undo my last navigation") instead of the engine's `prev_id`-based reverse-step-over, which could leap across contract boundaries when stepping into call bodies.
+- Update `install.sh` to download the latest release from GitHub Releases first, falling back to source builds when no releases are available.
+- README structure: prerequisites moved under "Build from Source"; RPC endpoint guidance moved into Quickstart; em-dashes removed.
+- Help overlay rows updated to match live menus (trace right-click items, ⌥F10 semantics, command palette command-mode prefill).
+- Display panel: Stack rows show a per-row depth `[N]`, top-of-stack badge, click-to-copy, and truncated hex with full-value tooltip; Memory view adds an ASCII gutter with 8-byte hex grouping.
+- Mobile website (`@media (pointer: coarse)`): trimmed fonts, icons, and structural rows so the IDE mock fits a phone-landscape viewport once browser chrome is accounted for; switched the shell height to `100dvh` so layout tracks the *visible* viewport as chrome shows or hides.
 
 ## [0.0.2] - 2024-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,29 +10,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.3] - 2026-05-10
 
 ### Added
+
+#### Engine / CLI
 - Support for calldata variables ([#33](https://github.com/edb-rs/edb/pull/33))
-- New `r` and `R` commands in code panel (`run`/`runback` in terminal panels) to run forward/backward until the next breakpoint
-- `edb server` which collectively spawns edb debug server. ([#46](https://github.com/edb-rs/edb/pull/46))
-- `release.yml` for automatic release publishing to GitHub Releases
-- **Browser-based web UI** as the default front-end: file tabs (Dockview), CodeMirror Solidity editor, command palette, debug toolbar with VSCode-style F-key bindings, Variables/Watch sidebar, Display panel (Stack / Memory / Storage / Transient / Calldata / Output), Terminal panel, and reopen menu. Source views auto-scroll to the active line; opcode views highlight the current PC and recover from missed scrolls via a global "Where am I?" toolbar button.
-- **Marketing website** (`website/`) with a fixed-shell tour, IDE mock, mobile-sheet popups, and a rotate-phone overlay; `edb.zzhang.xyz` runs the same bundle.
-- README: online tutor badge, sponsor split (GitHub Sponsors for individuals, mailto for companies, with a subtle DAPLab @ Columbia attribution).
+- `r` / `R` commands in the code panel (`run` / `runback` in terminal panels) to run forward / backward until the next breakpoint
+- `edb server` subcommand that collectively spawns the edb debug server ([#46](https://github.com/edb-rs/edb/pull/46))
+- New `--ui=web` option (and made it the default; see Changed)
+
+#### Browser-based web UI (`crates/web`)
+- **Dockview-based shell** with draggable file tabs and movable Display / Terminal panels (drop-on-edge to split, drop-on-tab to stack) and persisted layouts.
+- **CodeMirror 6 Solidity editor** with the EDB highlight theme, find panel (`Ctrl/Cmd+F`), gutter-click breakpoints, and a "Reveal current" toolbar button that scrolls the active line to center.
+- **Opcode view** with PC-aware current-instruction highlighting (matching accent stripe + dim background as the source view) and a `Reveal current PC` button.
+- **Debug toolbar** with VSCode-style bindings: Continue (F5), Step Into (F11), Step Out (⇧F11), Step Over (F10), Reverse Continue (⌥F5), Reverse Step (⌥F10), Restart (⇧⌘F5), Stop (⇧F5), Prev/Next Call (⌥←/⌥→), and a global "Where am I?" button that opens / focuses the file or disasm tab matching the active snapshot.
+- **Command palette** (`⌘P` / `Ctrl+P` to toggle, `⌘⇧P` for command-mode-prefilled-`>`) with file open, snapshot goto, and every toolbar action.
+- **Variables & Watch** sidebar with type-chipped variable cards and an inline `+` watch input; clicking an address value opens that contract's source in a new tab.
+- **Display panel** with Variables, Watch, Stack, Memory, Storage, Transient, Calldata, and Output tabs. Stack rows show a per-row depth `[N]`, a top-of-stack badge, truncated hex with a full-value tooltip, and click-to-copy. Memory adds an ASCII gutter with 8-byte hex grouping.
+- **Trace panel** with click-to-reveal-source (no snapshot change), right-click context menu (Jump to snapshot N · Reveal source only · Toggle children), and shift-click as a keyboard alternative for Jump.
+- **Breakpoints panel** with conditional and unconditional source / opcode breakpoints, a hit list, and "clear all".
+- **Terminal panel** with a Solidity REPL, terminal commands (`continue`, `step`, `over`, `out`, `goto <n>`, `break <addr>:<line>`, `break <addr>:pc=<pc>`, `bp`, `unbreak <#>`, `clear`, `help`), and an "Eye" chip that promotes the last expression to a watch.
+- **Help overlay** (status-bar `?`) covering stepping shortcuts, palette, trace tree, editor, variables / watch, terminal commands, and layout / panels — all rows verified against live behavior.
+- **Reopen menu** that lights up when a fixed panel (Display / Terminal) has been closed, restoring it next to its sibling.
+- **Status bar** with snapshot counter, connection indicator, theme toggle, and help button.
+- **Theme toggle** with light and dark themes shipped by default.
+- **Navigation history** (`navHistory`) with a 200-entry cap so Reverse Step is a true undo of the user's last navigation (step / continue / palette goto / trace click).
+- **Auto-follow active snapshot**: every snapshot change opens (or focuses) the file / disasm tab matching the new `(bytecode_address, source_path)` and re-pulses the in-tab scroll-to-current effect.
+- **Mobile layout** with stacked code / display, scaled fonts, and a popup sheet for stage hints.
+
+#### Marketing website (`website/`)
+- New fixed-shell SPA with a 10-stage tour, IDE mock, animated tour cursor, and stage-pip navigation; deployed at `edb.zzhang.xyz`.
+- Rich per-stage rail explanations with section headings, bullet lists, and starred recommendations.
+- Mobile-sheet popups for stage explanations on phones; click-anywhere-dismiss + tap-hint pulse.
+- Rotate-phone overlay shown for portrait phones; mobile chevrons for prev / next.
+- Side-by-side Display / Code layout for landscape phones, vertical stack for portrait.
+- Steppy mascot inline with the EDB wordmark in both the website hero and the README header.
+
+#### Documentation / branding
+- Online tutor badge in README pointing at `edb.zzhang.xyz`.
+- Sponsor split: GitHub Sponsors badge for individuals, mailto badge for companies, with a subtle "coordinated through DAPLab @ Columbia" attribution.
+- README header refreshed with new screenshots (web UI light + dark, TUI), Steppy icon, and shorter intro copy.
+- DEV.md notes the `EDB_SKIP_WEB_BUILD=1` escape hatch and bun-not-found troubleshooting.
+- `release.yml` for automatic release publishing to GitHub Releases (Bun installed before `cargo build --release` so prebuilt binaries always include the SPA).
 
 ### Fixed
 - Struct fields are no longer incorrectly treated as variables ([#33](https://github.com/edb-rs/edb/pull/33))
 - Gas limit relaxation is now correctly applied at callsites ([#39](https://github.com/edb-rs/edb/issues/39))
 - Web Memory view rendered nothing for opcode snapshots with empty memory; now shows an explicit `(empty)` placeholder.
-- Web opcode view's auto-scroll lost its target on backward navigation due to a single-ref-swap pattern; replaced with a `data-edb-current` attribute lookup that's order-independent.
-- Web tab focus didn't follow the active snapshot across contracts; `MainArea` now opens (or focuses) the file/disasm tab matching the snapshot on every change.
+- Web opcode view's auto-scroll lost its target on backward navigation due to a single-ref-swap pattern (React's commit cleared the shared ref when the previously-current row's `ref` flipped to `undefined`); replaced with a `data-edb-current` attribute lookup that's order-independent.
+- Web tab focus didn't follow the active snapshot across contracts; `MainArea` now opens (or focuses) the file / disasm tab matching the snapshot on every change.
+- Web reopen menu wasn't reactive to layout changes; subscribes to `layoutJson` so the affordance pops the moment a tab is closed.
+- Help overlay rendered behind the dockview surface in some browsers; z-index now ≥ 100.
+- Editor toolbar metadata wrapped when the source path was long; the file-name pill now truncates and the full path lives on the `title` attribute.
+- Mobile website's hit / watchpoint tags overlapped the source text on narrow viewports; tags now float above the line.
+- Mobile-website empty LOCALS placeholder hidden on phones; STATE VARIABLES alone is enough.
 
 ### Changed
-- `--ui` defaults to `web` (was `tui`); `--ui=tui` is the explicit fallback. Release pipeline already installs Bun, so prebuilt binaries ship with the embedded SPA baked in.
-- Reverse Step (`⌥F10`) is now a true history-pop ("undo my last navigation") instead of the engine's `prev_id`-based reverse-step-over, which could leap across contract boundaries when stepping into call bodies.
-- Update `install.sh` to download the latest release from GitHub Releases first, falling back to source builds when no releases are available.
-- README structure: prerequisites moved under "Build from Source"; RPC endpoint guidance moved into Quickstart; em-dashes removed.
-- Help overlay rows updated to match live menus (trace right-click items, ⌥F10 semantics, command palette command-mode prefill).
-- Display panel: Stack rows show a per-row depth `[N]`, top-of-stack badge, click-to-copy, and truncated hex with full-value tooltip; Memory view adds an ASCII gutter with 8-byte hex grouping.
-- Mobile website (`@media (pointer: coarse)`): trimmed fonts, icons, and structural rows so the IDE mock fits a phone-landscape viewport once browser chrome is accounted for; switched the shell height to `100dvh` so layout tracks the *visible* viewport as chrome shows or hides.
+- `--ui` defaults to `web` (was `tui`); `--ui=tui` is the explicit fallback. The release pipeline already installs Bun, so prebuilt binaries ship with the embedded SPA baked in.
+- Reverse Step (`⌥F10`) is now a true navigation-history pop ("undo my last navigation"). The engine's `prev_id`-based reverse-step-over could leap across contract boundaries when reverse-stepping out of a freshly-entered call body — replaced with a per-session `navHistory` stack populated on every `setSnapshotId`.
+- `install.sh` downloads the latest release from GitHub Releases first, falling back to source builds when no release matches the platform; source builds gate on `bun --version` resolving on PATH.
+- README structure: prerequisites moved under "Build from Source"; RPC endpoint guidance moved into Quickstart; em-dashes removed; sponsor framing reverted to the urgent "short on funding" line; sponsor section split into individual / company badges.
+- Snapshot ids in the web UI surface as 1-based (1 / N) in the status bar and palette while remaining 0-based on the wire.
+- Help overlay rows updated to match live menus (trace right-click items, ⌥F10 history-pop semantics, command palette command-mode prefill).
+- Web UI variable cards replace the previous flat list; trace tree is reveal-only on left-click; activity bar uses a colour palette; toolbars get verbose labels.
+- Mobile website (`@media (pointer: coarse) and ((max-width: 720px) or (max-height: 500px))`): trimmed fonts, icons, structural rows, and ide-mock-wrap padding so the IDE mock fits a phone-landscape viewport once browser chrome is accounted for; switched the shell height to `100dvh` so the layout tracks the *visible* viewport as chrome shows or hides.
+- README, DEV.md, ARCH.md, and HelpOverlay copy aligned with the new defaults / semantics; the in-code `Locate` references renamed to "Where am I?" to match the user-facing label.
 
 ## [0.0.2] - 2024-10-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "edb"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -2165,7 +2165,7 @@ dependencies = [
 
 [[package]]
 name = "edb-common"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-dyn-abi",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "edb-engine"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-contract",
@@ -2247,7 +2247,7 @@ dependencies = [
 
 [[package]]
 name = "edb-integration-tests"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -2271,7 +2271,7 @@ dependencies = [
 
 [[package]]
 name = "edb-rpc-proxy"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "alloy-chains",
  "alloy-json-rpc",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "edb-tui"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -2330,7 +2330,7 @@ dependencies = [
 
 [[package]]
 name = "edb-web"
-version = "0.0.2"
+version = "0.0.3"
 dependencies = [
  "axum",
  "http-body-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,7 +724,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -735,7 +735,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2066,7 +2066,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2430,7 +2430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4035,7 +4035,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5450,7 +5450,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5530,7 +5530,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5541,9 +5541,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6059,7 +6059,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6392,7 +6392,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6401,7 +6401,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8c27177b12a6399ffc08b98f76f7c9a1f4fe9fc967c784c5a071fa8d93cf7e1"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7350,7 +7350,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.2"
+version = "0.0.3"
 edition = "2024"
 # Remember to update clippy.toml as well
 rust-version = "1.89"
@@ -80,13 +80,13 @@ codegen-units = 1
 
 [workspace.dependencies]
 # workspace crates
-edb-engine = { version = "0.0.2", path = "crates/engine" }
-edb-common = { version = "0.0.2", path = "crates/common" }
-edb-rpc-proxy = { version = "0.0.2", path = "crates/rpc-proxy" }
-edb-integration-tests = { version = "0.0.2", path = "crates/integration-tests" }
-edb-tui = { version = "0.0.2", path = "crates/tui" }
-edb = { version = "0.0.2", path = "crates/edb" }
-edb-web = { version = "0.0.2", path = "crates/web" }
+edb-engine = { version = "0.0.3", path = "crates/engine" }
+edb-common = { version = "0.0.3", path = "crates/common" }
+edb-rpc-proxy = { version = "0.0.3", path = "crates/rpc-proxy" }
+edb-integration-tests = { version = "0.0.3", path = "crates/integration-tests" }
+edb-tui = { version = "0.0.3", path = "crates/tui" }
+edb = { version = "0.0.3", path = "crates/edb" }
+edb-web = { version = "0.0.3", path = "crates/web" }
 
 # alloy - aligned with Foundry's current workspace requirements
 alloy-chains = "0.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@
 </h1>
 
 <p align="center">
-  <strong>Source-level time-travel debugger for Ethereum smart contracts</strong>
+  <strong>To our knowledge, the first Ethereum smart-contract debugger that can theoretically achieve 100% accurate source-to-bytecode mapping.</strong>
+</p>
+
+<p align="center">
+  Source-level time-travel debugger for Ethereum smart contracts.
 </p>
 
 <p align="center">

--- a/crates/web/frontend/bun.lock
+++ b/crates/web/frontend/bun.lock
@@ -30,7 +30,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.0",
-        "happy-dom": "^16.0.0",
+        "happy-dom": "^20.0.0",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.0",
         "vite": "^6.0.0",
@@ -380,7 +380,7 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "happy-dom": ["happy-dom@16.8.1", "", { "dependencies": { "webidl-conversions": "^7.0.0", "whatwg-mimetype": "^3.0.0" } }, "sha512-n0QrmT9lD81rbpKsyhnlz3DgnMZlaOkJPpgi746doA+HvaMC79bdWkwjrNnGJRvDrWTI8iOcJiVTJ5CdT/AZRw=="],
+    "happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.6", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "style-to-js": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg=="],
 
@@ -598,8 +598,6 @@
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
-    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
-
     "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
@@ -611,8 +609,6 @@
     "zustand": ["zustand@5.0.13", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@happy-dom/global-registrator/happy-dom": ["happy-dom@20.9.0", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
 

--- a/crates/web/frontend/package.json
+++ b/crates/web/frontend/package.json
@@ -36,7 +36,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.0",
-    "happy-dom": "^16.0.0",
+    "happy-dom": "^20.0.0",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.0",
     "vite": "^6.0.0"


### PR DESCRIPTION
## Summary

Cuts v0.0.3. Addresses Dependabot alerts that have an easy fix path, expands the changelog to cover the work accumulated since v0.0.2, and adds a one-line claim under the README H1.

The `v0.0.3` tag is already in place on the head of this branch (`886f7c0`), per request, so release.yml fires on push and the GitHub Release auto-populates from the merged history.

## Workspace bump
- `Cargo.toml` workspace.package version 0.0.2 → 0.0.3
- All `workspace.dependencies` path-refs (edb-engine, edb-common, edb-rpc-proxy, edb-integration-tests, edb-tui, edb, edb-web) bumped 0.0.2 → 0.0.3
- `Cargo.lock` refreshed via `cargo check --workspace --all-features`
- External pins (alloy 2.0.1, foundry-compilers 0.20.0, revm 38.0.0, alloy-evm 0.34.0, etc.) verified aligned with foundry-rs/foundry's master `Cargo.toml` — no third-party version changes needed.

## Security
Closes / silences these Dependabot alerts via dep bumps:

- **happy-dom** dev-dependency in `crates/web/frontend`: `^16` → `^20.0.0`. Covers:
  - GHSA-37j7-fg3j-429f (critical, VM-context-escape RCE)
  - GHSA-w4gp-fjgq-3q4g (high, fetch credentials use page-origin cookies)
  - GHSA-6q6h-j7hj-3r64 (high, unsanitized export names in ECMAScriptModuleCompiler)
  Tests: 227/227 frontend tests pass on happy-dom 20.

- **rustls-webpki** transitive: `0.103.10` → `0.103.13` via `cargo update -p rustls-webpki`. Covers:
  - GHSA-82j2-j2ch-gfr8 (high, panic on malformed CRL BIT STRING)
  - GHSA-965h-392x-2mh5 (low, name constraints accepted for URI names)
  - GHSA-xgp8-3hg3-c2mh (low, name constraints accepted for wildcard certs)

**Skipped**:
- `rand` GHSA-cq8v-f236-94qc (low) — fix is in 0.10.1, a major bump from our pinned 0.9. Not an "easy fix without significant code change".
- `tracing-subscriber` GHSA-xwfj-jgwm-7wp5 (low) — already fixed: our `0.3.23` is past the `0.3.20` cut.

## CHANGELOG
Moves the prior `[Unreleased]` content into `[0.0.3] - 2026-05-10`, expanded to cover the v0.0.2 → 0.0.3 work: web UI default + every shipped panel/feature, marketing website, README/sponsor refresh, mobile-website polish, the auto-follow + Reverse-Step-history-pop fixes, and the help-overlay / install.sh updates.

## README
- Adds a one-line claim under the H1: *"To our knowledge, the first Ethereum smart-contract debugger that can theoretically achieve 100% accurate source-to-bytecode mapping."*
- Existing descriptive subtitle (*"Source-level time-travel debugger…"*) stays.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo check --workspace --all-features`
- [x] `cargo clippy --workspace --all-features --all-targets -- -D warnings`
- [x] `cargo build --workspace --all-features`
- [x] `bun test src/` — 227/0 (frontend, on happy-dom 20)
- [x] `release.yml` builds prebuilt binaries for all 5 targets and publishes the GitHub Release on tag push
- [x] Verify Dependabot alerts close on `main` after merge